### PR TITLE
Work around peewee issue when performing a comparison against None, fixes #65

### DIFF
--- a/classes/database.py
+++ b/classes/database.py
@@ -113,12 +113,12 @@ def create_status_types():
 
 
 def next_movie_to_compress():
-    for movie in Movies.select().where((Movies.statusid == 4) & (Movies.filename != None)):
+    for movie in Movies.select().where((Movies.statusid == 4) & (Movies.filename != "None")):
         return movie
 
 
 def next_movie_to_filebot():
-    for movie in Movies.select().where((Movies.statusid == 6) & (Movies.filename != None) & (Movies.filebot == 1)):
+    for movie in Movies.select().where((Movies.statusid == 6) & (Movies.filename != "None") & (Movies.filebot == 1)):
         return movie
 
 
@@ -135,6 +135,7 @@ def insert_movie(title, path, filebot):
     return Movies.create(
         moviename=title,
         path=path,
+        filename="None",
         filebot=filebot,
         statusid=1,
         lastupdated=datetime.now()


### PR DESCRIPTION
As discussed in the original issue, this works around the issue i've had on my Linux based NAS. My only concern with it is that if users update their version with movies in their queue, they wont be processed any more. I would kinda assume that "most" people would not update a version while outstanding jobs are in the DB, but you never know...
