### PR TITLE
Add (optional) ffmpeg support

### DIFF
--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -1,7 +1,9 @@
 __all__ = [
     'analytics',
+    'compression',
     'database',
     'docopt',
+    'ffmpeg',
     'filebot',
     'handbrake',
     'logger',

--- a/classes/compression.py
+++ b/classes/compression.py
@@ -1,0 +1,67 @@
+"""
+FFmpeg Wrapper
+
+
+Released under the MIT license
+Copyright (c) 2014, Ian Bird
+
+@category   misc
+@author     Ian Bird
+@license    http://opensource.org/licenses/MIT
+"""
+
+import os
+
+def create(config):
+    """
+        Creates the required compression instances
+
+        Inputs:
+            config    (??): The configuration
+
+        Outputs:
+            The compression instance
+    """
+    if config['type'] == "ffmpeg":
+        return ffmpeg.ffmpeg(config['debug'])
+    else:
+        return handbrake.handBrake(config['debug']);
+
+class compression(object):
+
+    def check_exists(self, dbMovie):
+        """
+            Checks to see if the file still exists at the path set in the
+                database
+
+            Inputs:
+                dbMovie (Obj): Movie database object
+
+            Outputs:
+                Bool    Does file exist
+
+        """
+        inMovie = "%s/%s" % (dbMovie.path, dbMovie.filename)
+
+        if os.path.isfile(inMovie):
+            return True
+
+        else:
+            self.log.debug(inMovie)
+            self.log.error("Input file no longer exists")
+            return False
+
+    def _cleanUp(self, cFile):
+        """
+            Deletes files once the compression has finished with them
+
+            Inputs:
+                cFile    (Str): File path of the movie to remove
+
+            Outputs:
+                None
+        """
+        try:
+            os.remove(cFile)
+        except:
+            self.log.error("Could not remove %s" % cFile)

--- a/classes/ffmpeg.py
+++ b/classes/ffmpeg.py
@@ -1,0 +1,66 @@
+"""
+FFmpeg Wrapper
+
+
+Released under the MIT license
+Copyright (c) 2014, Ian Bird
+
+@category   misc
+@author     Ian Bird
+@license    http://opensource.org/licenses/MIT
+"""
+
+import os
+import subprocess
+import logger
+
+from compression import compression
+
+class ffmpeg(compression):
+
+    def __init__(self, debug):
+        self.log = logger.logger("FFmpeg", debug)
+
+    def compress(self, nice, args, dbMovie):
+        """
+            Passes the nessesary parameters to FFmpeg to start an encoding
+            Assigns a nice value to allow give normal system tasks priority
+
+            Upon successful encode, clean up the output logs and remove the
+                input movie as they are no longer needed
+
+            Inputs:
+                nice    (Int): Priority to assign to task (nice value)
+                args    (Str): All of the FFmpeg arguments taken from the
+                                settings file
+                output  (Str): File to log to. Used to see if the job completed
+                                successfully
+
+            Outputs:
+                Bool    Was convertion successful
+        """
+
+        moviename = "%s.mkv" % dbMovie.moviename
+        inMovie = "%s/%s" % (dbMovie.path, dbMovie.filename)
+        outMovie = "%s/%s" % (dbMovie.path, moviename)
+
+        command = 'nice -n {0} ffmpeg -i "{1}" {2} "{3}"'.format(
+            nice,
+            inMovie,
+            ' '.join(args),
+            outMovie
+        )
+
+        proc = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=True
+        )
+        (results, errors) = proc.communicate()
+
+        if proc.returncode is not 0:
+            self.log.error("FFmpeg (compress) returned status code: %d" % proc.returncode)
+            return False
+
+        return True

--- a/classes/handbrake.py
+++ b/classes/handbrake.py
@@ -14,49 +14,14 @@ Copyright (c) 2012, Jason Millward
 import os
 import subprocess
 import logger
+import compression
 
+from compression import compression
 
-class handBrake(object):
+class handBrake(compression):
 
     def __init__(self, debug):
         self.log = logger.logger("HandBrake", debug)
-
-    def _cleanUp(self, cFile):
-        """
-            Deletes files once HandBrake is finished with them
-
-            Inputs:
-                cFile    (Str): File path of the movie to remove
-
-            Outputs:
-                None
-        """
-        try:
-            os.remove(cFile)
-        except:
-            self.log.error("Could not remove %s" % cFile)
-
-    def check_exists(self, dbMovie):
-        """
-            Checks to see if the file still exists at the path set in the
-                database
-
-            Inputs:
-                dbMovie (Obj): Movie database object
-
-            Outputs:
-                Bool    Does file exist
-
-        """
-        inMovie = "%s/%s" % (dbMovie.path, dbMovie.filename)
-
-        if os.path.isfile(inMovie):
-            return True
-
-        else:
-            self.log.debug(inMovie)
-            self.log.error("Input file no longer exists")
-            return False
 
     def compress(self, nice, args, dbMovie):
         """

--- a/classes/testing.py
+++ b/classes/testing.py
@@ -21,7 +21,8 @@ def perform_testing(config):
     requirements = {
         "MakeMKV":   "makemkvcon",
         "Filebot":   "filebot",
-        "HandBrake": "HandBrakeCLI"
+        "HandBrake": "HandBrakeCLI",
+        "FFmpeg (optional)": "ffmpeg"
     }
 
     print "= Checking directory permissions"

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -11,7 +11,12 @@ makemkv:
     # Eject the disk
     eject:      True
 
-handbrake:
+compress:
+    # The compression application to use.
+    #   handbrake: Compress the video using Handbrake
+    #   ffmpeg: Compress the video using ffmpeg
+    type:       handbrake
+
     # The scheduling priority of the HandBrake program
     #   -20 is the highest (The task gets top priority)
     #    19 is the lowest  (The task get no priority and runs on spare CPU cycles)
@@ -29,6 +34,14 @@ handbrake:
         -   --x264-tune="film"
         -   --encoder="x264"
         -   -s 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20
+
+    # Example ffmpeg command line
+    #com:
+    #    -   -map 0
+    #    -   -c copy
+    #    -   -c:v libx264
+    #    -   -crf 20
+    #    -   -preset medium
 
 filebot:
     # Enable filebot renaming


### PR DESCRIPTION
Here's a pull request for your consideration...

I was trying to setup a linux based NAS (x86) machine that I could push my video collection to, and then overnight it would process any outstanding queued items. The main issue that I had was that Handbrake was a giant pain to try and build for my specific setup. Although you can build it without a number of dependencies to get the command line version, it still required a significant amount of components. It was much easier to simply build ffmpeg which is arguably more powerful a command line tool, than Handbrake.

These changes add support for using ffmpeg instead of handbrake, although the default remains handbrake. The example settings are also similar to what's present for handbrake, e.g. copy all audio/subtitle streams, but encode the video using libx264 (medium preset with constant quality of 20). 

If you are interested in including these changes, and have any review comments, just let me know and i'll fix them up...
