### PR TITLE
Handle applications outside of $PATH

### DIFF
--- a/autorippr.py
+++ b/autorippr.py
@@ -201,7 +201,7 @@ def compress(config):
     if config['compress']['type'] == "ffmpeg":
         comp = ffmpeg.ffmpeg(config['debug'])
     else:
-        comp = handbrake.handBrake(config['debug']);
+        comp = handbrake.handBrake(config['debug'], config['compress']['compressionPath']);
 
     log.debug("Compressing initialised")
     log.debug("Looking for movies to compress")

--- a/classes/compression.py
+++ b/classes/compression.py
@@ -25,7 +25,7 @@ def create(config):
     if config['type'] == "ffmpeg":
         return ffmpeg.ffmpeg(config['debug'])
     else:
-        return handbrake.handBrake(config['debug']);
+        return handbrake.handBrake(config['debug'], config['compression']['compressionPath']);
 
 class compression(object):
 

--- a/classes/handbrake.py
+++ b/classes/handbrake.py
@@ -20,6 +20,7 @@ class handBrake(object):
 
     def __init__(self, debug):
         self.log = logger.logger("HandBrake", debug)
+        self.handbrakecliPath = config['handbrake']['handbrakecliPath']
 
     def _cleanUp(self, cFile):
         """
@@ -87,7 +88,7 @@ class handBrake(object):
                 'nice',
                 '-n',
                 str(nice),
-                'HandBrakeCLI',
+                '%sHandBrakeCLI' %s self.handbrakecliPath,
                 '--verbose',
                 str(1),
                 '-i',

--- a/classes/handbrake.py
+++ b/classes/handbrake.py
@@ -20,9 +20,9 @@ from compression import compression
 
 class handBrake(compression):
 
-    def __init__(self, debug):
+    def __init__(self, debug, compressionPath):
         self.log = logger.logger("HandBrake", debug)
-        self.handbrakecliPath = config['handbrake']['handbrakecliPath']
+        self.compressionPath = compressionPath
 
     def compress(self, nice, args, dbMovie):
         """
@@ -48,11 +48,12 @@ class handBrake(compression):
         inMovie = "%s/%s" % (dbMovie.path, dbMovie.filename)
         outMovie = "%s/%s" % (dbMovie.path, moviename)
 
-        command = 'nice -n {0} HandBrakeCLI --verbose -i "{1}" -o "{2}" {3}'.format(
+        command = 'nice -n {0} {4}HandBrakeCLI --verbose -i "{1}" -o "{2}" {3}'.format(
             nice, 
             inMovie, 
             outMovie, 
-            ' '.join(args)
+            ' '.join(args),
+            self.compressionPath
         )
  
         proc = subprocess.Popen(

--- a/classes/makemkv.py
+++ b/classes/makemkv.py
@@ -200,7 +200,7 @@ class makeMKV(object):
         """
         drives = []
         proc = subprocess.Popen(
-            ['makemkvcon', '-r', 'info', 'disc:-1'],
+            ['%smakemkvcon' % self.makemkvconPath, '-r', 'info', 'disc:-1'],
             stderr=subprocess.PIPE,
             stdout=subprocess.PIPE
         )
@@ -256,7 +256,7 @@ class makeMKV(object):
 
         proc = subprocess.Popen(
             [
-                '%smakemkvcon' % makemkvconPath,
+                '%smakemkvcon' % self.makemkvconPath,
                 '-r',
                 'info',
                 'disc:%d' % self.discIndex,

--- a/classes/makemkv.py
+++ b/classes/makemkv.py
@@ -28,6 +28,7 @@ class makeMKV(object):
         self.minLength = int(config['makemkv']['minLength'])
         self.cacheSize = int(config['makemkv']['cache'])
         self.log = logger.logger("Makemkv", config['debug'])
+        self.makemkvconPath = config['makemkv']['makemkvconPath']
 
     def _clean_title(self):
         """
@@ -131,7 +132,7 @@ class makeMKV(object):
 
         proc = subprocess.Popen(
             [
-                'makemkvcon',
+                '%smakemkvcon' % self.makemkvconPath,
                 'mkv',
                 'disc:%d' % self.discIndex,
                 '0',
@@ -192,7 +193,7 @@ class makeMKV(object):
         """
         drives = []
         proc = subprocess.Popen(
-            ['makemkvcon', '-r', 'info'],
+            ['%smakemkvcon' % self.makemkvconPath, '-r', 'info'],
             stderr=subprocess.PIPE,
             stdout=subprocess.PIPE
         )
@@ -245,7 +246,7 @@ class makeMKV(object):
 
         proc = subprocess.Popen(
             [
-                'makemkvcon',
+                '%smakemkvcon' % makemkvconPath,
                 '-r',
                 'info',
                 'disc:%d' % self.discIndex,

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -15,6 +15,9 @@ makemkv:
     eject:      True
 
 handbrake:
+    # Path to HandBrakeCLI (with trailing slash) in case it is unavailable in your $PATH
+    handbrakecliPath:
+
     # The scheduling priority of the HandBrake program
     #   -20 is the highest (The task gets top priority)
     #    19 is the lowest  (The task get no priority and runs on spare CPU cycles)

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -1,6 +1,6 @@
 makemkv:
     # Path to makemkvcon (with trailing slash) in case it is unavailable in your $PATH
-    makemkvconPath: 
+    makemkvconPath: ""
 
     # This is where the ripped movies go
     savePath:   /tmp/
@@ -15,8 +15,8 @@ makemkv:
     eject:      True
 
 compress:
-    # Path to HandBrakeCLI (with trailing slash) in case it is unavailable in your $PATH
-    compressionPath:
+    # Path to compression app (with trailing slash) in case it is unavailable in your $PATH
+    compressionPath: ""
 
     # The compression application to use.
     #   handbrake: Compress the video using Handbrake

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -1,4 +1,7 @@
 makemkv:
+    # Path to makemkvcon (with trailing slash) in case it is unavailable in your $PATH
+    makemkvconPath: 
+
     # This is where the ripped movies go
     savePath:   /tmp/
 


### PR DESCRIPTION
In the event that `HandBrakeCLI` or `makemkvcon` are unavailable in `$PATH` (in my instance, both were installed in OS X using brew), I've added two additional configuration parameters for the full path to the binaries.

I've then tweaked the `handbrake` and `makemkv` classes to make use of these configuration variables when executing those commands.

I didn't bother doing the same with filebot as this application is installed via the AppStore on OS X, so presumably the application would be available. I don't have the app to test, though.