### PR TITLE
Append titleId for multi-title discs

### DIFF
--- a/autorippr.py
+++ b/autorippr.py
@@ -148,12 +148,15 @@ def rip(config):
 
                     # Force filebot disable for multiple titles
                     forceDisableFB = True if len( saveFiles ) > 1 else False
+                    multiTitle = True if len( saveFiles ) > 1 else False
 
                     for dvdTitle in saveFiles:
 
                         dbmovie = database.insert_movie(
                             movie_title,
                             movie_path,
+                            multiTitle,
+                            dvdTitle['index'],
                             forceDisableFB
                         )
 

--- a/classes/database.py
+++ b/classes/database.py
@@ -46,6 +46,8 @@ class Historytypes(BaseModel):
 class Movies(BaseModel):
     movieid = PrimaryKeyField(db_column='movieID')
     moviename = CharField()
+    multititle = BooleanField()
+    titleindex = CharField(db_column='titleIndex')
     path = CharField()
     filename = CharField(null=True)
     filebot = BooleanField()
@@ -131,9 +133,11 @@ def insert_history(dbmovie, text, typeid=1):
     )
 
 
-def insert_movie(title, path, filebot):
+def insert_movie(title, path, multititle, index, filebot):
     return Movies.create(
         moviename=title,
+        multititle=multititle,
+        titleindex=index,
         path=path,
         filename="None",
         filebot=filebot,

--- a/classes/ffmpeg.py
+++ b/classes/ffmpeg.py
@@ -37,7 +37,11 @@ class FFmpeg(object):
                 Bool    Was convertion successful
         """
 
-        moviename = "%s.mkv" % dbmovie.moviename
+        if (dbmovie.multititle):
+            moviename = "%s-%s.mkv" % (dbmovie.moviename, dbmovie.titleindex)
+        else:
+            moviename = "%s.mkv" % dbmovie.moviename
+
         inmovie = "%s/%s" % (dbmovie.path, dbmovie.filename)
         outmovie = "%s/%s" % (dbmovie.path, moviename)
 

--- a/classes/handbrake.py
+++ b/classes/handbrake.py
@@ -38,7 +38,11 @@ class HandBrake(object):
         """
         checks = 0
 
-        moviename = "%s.mkv" % dbmovie.moviename
+        if (dbmovie.multititle):
+            moviename = "%s-%s.mkv" % (dbmovie.moviename, dbmovie.titleindex)
+        else:
+            moviename = "%s.mkv" % dbmovie.moviename
+            
         inmovie = "%s/%s" % (dbmovie.path, dbmovie.filename)
         outmovie = "%s/%s" % (dbmovie.path, moviename)
         command = 'nice -n {0} {1}HandBrakeCLI --verbose -i "{2}" -o "{3}" {4}'.format(


### PR DESCRIPTION
Fixes issues with Handbrake overwriting files and only a single title
remaining after encoding completes.

**However**, I made schema changes to the database, and this required me deleting the existing autorippr.sqlite database for it to run. I'm currently saving the titleId and whether the disc was multi-title, meaning multiple titles would have normally overwritten.

I'm now sure if you a) want to delete the existing sqlite database automatically somehow, or b) change this to not need the info stored in the database.

I've tested this with 2 movies so far, a single title and multi-title, and it works fine with both.

Inception (multi title) ended up with the appropriate files:

    Inception-0.mkv
    Inception-1.mkv

And The Hobbit (single title) did as well:

    Hobbit Part1.mkv
