### PR TITLE
Update autorippr.py

### DIFF
--- a/autorippr.py
+++ b/autorippr.py
@@ -53,6 +53,7 @@ Options:
 import os
 import sys
 import yaml
+import errno
 import subprocess
 from classes import *
 from tendo import singleton


### PR DESCRIPTION
Received NameError when running the `--extra` argument.
```
Traceback (most recent call last):
  File "autorippr.py", line 395, in <module>
    extras(config)
  File "autorippr.py", line 361, in extras
    if ex.errno == errno.ENOTEMPTY:
NameError: global name 'errno' is not defined
```
Problem resided with removal of directory lacking the errno library.