### PR TITLE
Fix title cleanup and detection

### DIFF
--- a/autorippr.py
+++ b/autorippr.py
@@ -137,8 +137,8 @@ def rip(config):
             mkv_api.set_title(dvd["discTitle"])
             mkv_api.set_index(dvd["discIndex"])
 
-            disc_type = mkv_api.get_type()
             disc_title = mkv_api.get_title()
+            disc_type = mkv_api.get_type()
 
             disc_path = '{}/{}'.format(mkv_save_path, disc_title)
             if not os.path.exists(disc_path):

--- a/classes/makemkv.py
+++ b/classes/makemkv.py
@@ -50,7 +50,7 @@ class MakeMKV(object):
         tmpname = tmpname.title().replace("Extended_Edition", "")
         tmpname = tmpname.replace("Special_Edition", "")
         tmpname = re.sub(r"Disc_(\d)(.*)", r"D\1", tmpname)
-        tmpname = re.sub(r"Disc(\d)(.*)", r"D\1", tmpname)
+        tmpname = re.sub(r"Disc\s*(\d)(.*)", r"D\1", tmpname)
         tmpname = re.sub(r"Season_(\d)", r"S\1", tmpname)
         tmpname = re.sub(r"Season(\d)", r"S\1", tmpname)
         tmpname = re.sub(r"S(\d)_", r"S\1", tmpname)
@@ -356,8 +356,10 @@ class MakeMKV(object):
         )
 
         if titlePattern.search(self.vidName):
+            self.log.debug("Detected TV {}".format(self.vidName))
             self.vidType = "tv"
         else:
+            self.log.debug("Detected movie {}".format(self.vidName))
             self.vidType = "movie"
         return self.vidType
 


### PR DESCRIPTION
I am backing up some TV series with the title format `XYZ Disc #`.

I encountered two issues:

1) The `Disc(\d)` regex will not capture these titles due to the whitespace character.
2) The `get_type()` detection is done before `get_title()` therefore it will not pick up the fixed-up titles, and the TV series gets detected as a movie. (Note that `get_title()` changes the `self.vidName` variable.)

I fixed these two problems and I've also added a few more debug messages.