### PR TITLE
Updated Java Install proceedure for Filebot prerequisite

### DIFF
--- a/autorippr_install_script.sh
+++ b/autorippr_install_script.sh
@@ -53,8 +53,12 @@ sudo apt-get install handbrake-cli
 # Python update to enable next step
 sudo apt-get install python-dev
 
+# Install Java prerequisite for Filebot
+sudo add-apt-repository -y ppa:webupd8team/java
+sudo apt-get update
+sudo apt-get install oracle-java8-installer
+
 # Install Filebot
-sudo apt-get --assume-yes install oracle-java8-installer
 if [ `uname -m` = "i686" ]
 then
    wget -O filebot-i386.deb 'http://filebot.sourceforge.net/download.php?type=deb&arch=i386'


### PR DESCRIPTION
Filebot was previously reported as installed, but found through more testing that it would not load. Most likely cause was the Java installation wasn't happening as previously thought it was. So I have updated the script to resolve that.