### PR TITLE
Add docker build to Autorippr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+COPY /build/* /
+
+RUN echo "deb http://ppa.launchpad.net/stebbins/handbrake-releases/ubuntu xenial main ">/etc/apt/sources.list.d/handbreak.list && apt-get update && apt-get install --allow-unauthenticated -y python-pip handbrake-cli libssl1.0.0 libexpat1 libavcodec-ffmpeg56 libgl1-mesa-glx unzip 
+#libavcodec-ffmpeg-extra56
+
+
+ADD https://github.com/JasonMillward/Autorippr/archive/v1.7.0.zip autorippr-1.7.0.zip
+ADD "http://downloads.sourceforge.net/project/filebot/filebot/FileBot_4.7.2/filebot_4.7.2_amd64.deb?r=http%3A%2F%2Fwww.filebot.net%2F&ts=1473715379&use_mirror=freefr" filebot_4.7.2_amd64.deb
+RUN pip install tendo pyyaml peewee
+RUN unzip /autorippr-1.7.0.zip
+RUN dpkg -i filebot_4.7.2_amd64.deb
+
+ADD settings.example.cfg /Autorippr-1.7.0/settings.cfg
+
+ENTRYPOINT ["python", "/Autorippr-1.7.0/autorippr.py"]
+

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+#
+# Createas a container with autorippr in 
+#
+# Run like
+#
+# docker run -ti -v /tmp:/tmp  --device=/dev/sr1 autorippr --all --debug
+#
+
+
+docker build -t buildmakemkv ./build_makemkv
+docker run --rm buildmakemkv | tar xz
+docker build -t autorippr .

--- a/build_makemkv/Dockerfile
+++ b/build_makemkv/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y python-virtualenv build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev 
+
+ADD http://www.makemkv.com/download/makemkv-oss-1.10.2.tar.gz /src/
+ADD http://www.makemkv.com/download/makemkv-bin-1.10.2.tar.gz /src/
+
+RUN tar xf /src/makemkv-bin-1.10.2.tar.gz -C /src
+
+
+RUN mkdir /src/makemkv-bin-1.10.2/tmp/
+RUN echo 'accepted' > /src/makemkv-bin-1.10.2/tmp/eula_accepted
+
+RUN  sed -ie 's#DESTDIR=#DESTDIR=/build#g' /src/makemkv-bin-1.10.2/Makefile
+
+RUN cd /src/makemkv-bin-1.10.2 && make install
+
+RUN tar xf /src/makemkv-oss-1.10.2.tar.gz -C /src
+
+RUN cd /src/makemkv-oss-1.10.2 && ./configure --prefix /build/usr --disable-gui && make install
+
+CMD ["tar", "cz", "/build"]


### PR DESCRIPTION
This adds initial support for building a Docker image with Autorippr in it.

This has not been optimised for size and could do with some tidying up but this is the first pass.

You can use it by running " docker run -ti -v /tmp:/tmp  --device=/dev/sr1 autorippr --all" 

Todo.

Make config options overridable by env vars?
Shrink image
...
