### PR TITLE
Add forced subtitles and DB lookup options

### DIFF
--- a/autorippr.py
+++ b/autorippr.py
@@ -344,6 +344,22 @@ def extras(config):
     dbvideos = database.next_video_to_filebot()
 
     for dbvideo in dbvideos:
+        if config['ForcedSubs']['enable']:
+            forced = mediainfo.ForcedSubs(config)
+            log.info("Attempting to discover foreign subtitle for {}.".format(dbvideo.vidname))
+            track = forced.discover_forcedsubs(dbvideo)
+
+            if track is not None:
+                log.info("Found foreign subtitle for {}: track {}".format(dbvideo.vidname, track))
+                log.debug("Attempting to flag track for {}: track {}".format(dbvideo.vidname, track))
+                flagged = forced.flag_forced(dbvideo, forced)
+                if flagged:
+                    log.info("Flagging success.")
+                else:
+                    log.debug("Flag failed")
+            else:
+                log.debug("Did not find foreign subtitle for {}.".format(dbvideo.vidname))
+                
         log.info("Attempting video rename")
 
         database.update_video(dbvideo, 7)
@@ -391,21 +407,6 @@ def extras(config):
                 log.info("Not grabbing subtitles")
                 database.update_video(dbvideo, 8)
 
-        if config['ForcedSubs']['enable']:
-            forced = mediainfo.ForcedSubs(config)
-            log.info("Attempting to discover foreign subtitle for {}.".format(dbvideo.vidname))
-            track = forced.discover_forcedsubs(dbvideo)
-
-            if track is not None:
-                log.info("Found foreign subtitle for {}: track {}".format(dbvideo.vidname, track))
-                log.debug("Attempting to flag track for {}: track {}".format(dbvideo.vidname, track))
-                flagged = forced.flag_forced(dbvideo, forced)
-                if flagged:
-                    log.info("Flagging success.")
-                else:
-                    log.debug("Flag failed")
-            else:
-                log.debug("Did not find foreign subtitle for {}.".format(dbvideo.vidname))
 
 
             if 'extra' in config['notification']['notify_on_state']:

--- a/autorippr.py
+++ b/autorippr.py
@@ -333,7 +333,7 @@ def compress(config):
 
 def extras(config):
     """
-        Main function for filebotting
+        Main function for filebotting and flagging forced subs
         Does everything
         Returns nothing
     """
@@ -390,6 +390,25 @@ def extras(config):
             else:
                 log.info("Not grabbing subtitles")
                 database.update_video(dbvideo, 8)
+
+        if config['ForcedSubs']['enable']:
+            forced = mediainfo.ForcedSubs(config)
+            log.debug("Attempting to discover foreign subtitle for {}.".format(dbvideo.vidname))
+            forced.discover_forcedsubs(dbvideo)
+
+            if forced is not None:
+                log.info("Found foreign subtitle for {}: track {}".format(dbvideo.vidname, forced))
+                log.debug("Attempting to flag trackvfor {}: track {}".format(dbvideo.vidname, forced))
+                flagged = forced.flag_forced(dbvideo)
+            else:
+                log.debug("Did not find foreign subtitle for {}.").format(dbvideo.vidname)
+
+            if flagged:
+                log.info("Flagging success")
+            else:
+                log.debug("Flag failed.")
+
+
 
             if 'extra' in config['notification']['notify_on_state']:
                 notify.extra_complete(dbvideo)

--- a/autorippr.py
+++ b/autorippr.py
@@ -393,7 +393,7 @@ def extras(config):
 
         if config['ForcedSubs']['enable']:
             forced = mediainfo.ForcedSubs(config)
-            log.debug("Attempting to discover foreign subtitle for {}.".format(dbvideo.vidname))
+            log.info("Attempting to discover foreign subtitle for {}.".format(dbvideo.vidname))
             track = forced.discover_forcedsubs(dbvideo)
 
             if track is not None:

--- a/autorippr.py
+++ b/autorippr.py
@@ -401,7 +401,7 @@ def extras(config):
                 log.debug("Attempting to flag track for {}: track {}".format(dbvideo.vidname, track))
                 flagged = forced.flag_forced(dbvideo, forced)
             else:
-                log.debug("Did not find foreign subtitle for {}.").format(dbvideo.vidname)
+                log.debug("Did not find foreign subtitle for {}.".format(dbvideo.vidname))
 
             if flagged:
                 log.info("Flagging success")

--- a/autorippr.py
+++ b/autorippr.py
@@ -394,12 +394,12 @@ def extras(config):
         if config['ForcedSubs']['enable']:
             forced = mediainfo.ForcedSubs(config)
             log.debug("Attempting to discover foreign subtitle for {}.".format(dbvideo.vidname))
-            forced.discover_forcedsubs(dbvideo)
+            track = forced.discover_forcedsubs(dbvideo)
 
-            if forced is not None:
-                log.info("Found foreign subtitle for {}: track {}".format(dbvideo.vidname, forced))
-                log.debug("Attempting to flag trackvfor {}: track {}".format(dbvideo.vidname, forced))
-                flagged = forced.flag_forced(dbvideo)
+            if track is not None:
+                log.info("Found foreign subtitle for {}: track {}".format(dbvideo.vidname, track))
+                log.debug("Attempting to flag track for {}: track {}".format(dbvideo.vidname, track))
+                flagged = forced.flag_forced(dbvideo, forced)
             else:
                 log.debug("Did not find foreign subtitle for {}.").format(dbvideo.vidname)
 

--- a/autorippr.py
+++ b/autorippr.py
@@ -400,14 +400,12 @@ def extras(config):
                 log.info("Found foreign subtitle for {}: track {}".format(dbvideo.vidname, track))
                 log.debug("Attempting to flag track for {}: track {}".format(dbvideo.vidname, track))
                 flagged = forced.flag_forced(dbvideo, forced)
+                if flagged:
+                    log.info("Flagging success.")
+                else:
+                    log.debug("Flag failed")
             else:
                 log.debug("Did not find foreign subtitle for {}.".format(dbvideo.vidname))
-
-            if flagged:
-                log.info("Flagging success")
-            else:
-                log.debug("Flag failed.")
-
 
 
             if 'extra' in config['notification']['notify_on_state']:

--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     'handbrake',
     'logger',
     'makemkv',
+    'mediainfo',
     'notification',
     'stopwatch',
     'testing',

--- a/classes/filebot.py
+++ b/classes/filebot.py
@@ -53,9 +53,7 @@ class FileBot(object):
                 '--db',
                 '%s' % db,
                 '--output',
-                "%s" % movePath,
-                '--format',
-                "{plex}"
+                "%s" % movePath
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -28,12 +28,6 @@ import logger
 import shlex
 import subprocess
 
-
-class dvideo_test(object):
-    def __init__(self, filepath, filename):
-        self.path = filepath
-        self.filename = filename
-
 # main class that initializes settings for discovering/flagging a forced subtitle track
 # edits python's os.environ in favor of putting full string when calling executables
 class ForcedSubs(object):

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -83,7 +83,7 @@ class ForcedSubs(object):
 #   Main language subtitle assumed to be largest
         main_sub = subs[0]
         main_subsize = main_sub['stream_size']
-        main_sublen = int(main_sub['duration'])
+        main_sublen = float(main_sub['duration'])
 #   Checks other subs for size, duration, and if forced flag is set
         for sub in subs[1:]:
             if (

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jan 09 11:20:23 2017
+
+Dependencies:
+   System:
+       mediainfo
+       mkvtoolnix
+
+   Python (nonstandard library):
+       pymediainfo
+
+For Windows, if mediainfo or mkvpropedit aren't in PATH, must give path to .dll (mediainfo)
+or .exe (mkvpropedit) file
+For *nixs, use path to binary (although it's likly in PATH)
+
+Takes an mkv file and analyzes it for foreign subtitle track. Assumes that foreign subtitle
+track files are smaller in bit size but the same length as the main language track
+
+
+@author: brodi
+"""
+
+import os
+from pymediainfo import MediaInfo
+import logger
+import shlex
+import subprocess
+
+
+class dvideo_test(object):
+    def __init__(self, filepath, filename):
+        self.path = filepath
+        self.filename = filename
+
+# main class that initializes settings for discovering/flagging a forced subtitle track
+# edits python's os.environ in favor of putting full string when calling executables
+class ForcedSubs(object):
+    def __init__(self, config):
+        self.log = logger.Logger('ForcedSubs', config['debug'], config['silent'])
+        self.lang = config['ForcedSubs']['language']
+        self.secsub_ratio = float(config['ForcedSubs']['ratio'])
+        self.mediainfoPath = config['ForcedSubs']['mediainfoPath']
+        self.mkvpropeditPath = config['ForcedSubs']['mkvpropeditPath']
+        if (self.mediainfoPath and
+            os.path.dirname(self.mediainfoPath) not in os.environ['PATH']):
+            os.environ['PATH'] = (os.path.dirname(config['ForcedSubs']['mediainfoPath']) + ';' +
+                                  os.environ['PATH'])
+        if (self.mkvpropeditPath and
+            os.path.dirname(self.mkvpropeditPath) not in os.environ['PATH']):
+            os.environ['PATH'] = (os.path.dirname(config['ForcedSubs']['mkvpropeditPath']) + ';' +
+                                  os.environ['PATH'])
+
+    def discover_forcedsubs(self, dbvideo):
+        """
+            Attempts to find foreign subtitle track
+
+            Input:
+                dbvideo (Obj): Video database object
+
+            Output:
+                If successful, track number of forced subtitle
+                Else, None
+        """
+        MEDIADIR = os.path.join(dbvideo.path, dbvideo.filename)
+#        wrapper class for mediainfo tool
+        media_info = MediaInfo.parse(MEDIADIR)
+        subs = []
+#       Iterates though tracks and finds subtitles in preferred language, creates
+#       list of dictionaries
+        for track in media_info.tracks:
+            data = track.to_data()
+            if data['track_type'] == 'Text' and data['language']==self.lang:
+                subs.append(data)
+        if len(subs) <= 1:
+            self.log.info("Only one {} found, cannot determine foreign language track."
+                          .format(self.lang))
+            return None
+
+#   Sort list by size of track file
+        subs.sort(key=lambda sub: sub['stream_size'], reverse = True)
+
+#   Main language subtitle assumed to be largest
+        main_sub = subs[0]
+        main_subsize = main_sub['stream_size']
+        main_sublen = main_sub['duration']
+#   Checks other subs for size, duration, and if forced flag is set
+        for sub in subs[1:]:
+            if (
+                sub['stream_size'] <= main_subsize*self.secsub_ratio
+                and sub['duration'] == main_sublen
+                and sub['forced']=='No'
+                ):
+                secondary_sub = sub
+            else:
+                self.log.info("No forgeign language subtitle found, try adjusting ratio.")
+                return None
+        return secondary_sub['track_id']
+
+    def flag_forced(self, dbvideo, track):
+        """
+            Uses mkvpropedit to edit mkv header and flag the detected track as 'forced'
+
+            Input:
+                dbvideo (Obj): Video database object
+                track (int): Track number of foreign track to be flagged as 'forced'
+
+            Output:
+                Bool: Returns True of successful, returns False if not
+        """
+
+        MEDIADIR = os.path.join(dbvideo.path, dbvideo.filename)
+        cmd_raw = 'mkvpropedit {} --edit track:{} --set flag-forced=1'.format(MEDIADIR, track)
+        cmd = shlex.subprocesslit(cmd_raw)
+
+        proc = subprocess.Popen(
+                                cmd,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE
+                                )
+
+        (results, errors) = proc.communicate()
+
+        if proc.returncode is not 0:
+            self.log.error(
+                           "mkvpropedit (forced subtitles) returned status code {}".format(proc.returncode)
+                           )
+            return False
+
+        if len(results) is not 0:
+            lines = results.split('\n')
+            for line in lines:
+                self.log.debug(line.strip())
+
+        return True
+

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -88,12 +88,12 @@ class ForcedSubs(object):
         for sub in subs[1:]:
             if (
                 sub['stream_size'] <= main_subsize*self.secsub_ratio
-                and sub['duration'] == main_sublen
+                and main_sublen*.9 <= sub['duration'] <= main_sublen*1.1
                 and sub['forced']=='No'
                 ):
                 secondary_sub = sub
             else:
-                self.log.info("No forgeign language subtitle found, try adjusting ratio.")
+                self.log.info("No foreign language subtitle found, try adjusting ratio.")
                 return None
         return secondary_sub['track_id']
 

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -83,7 +83,7 @@ class ForcedSubs(object):
 #   Main language subtitle assumed to be largest
         main_sub = subs[0]
         main_subsize = main_sub['stream_size']
-        main_sublen = main_sub['duration']
+        main_sublen = int(main_sub['duration'])
 #   Checks other subs for size, duration, and if forced flag is set
         for sub in subs[1:]:
             if (

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -23,6 +23,7 @@ track files are smaller in bit size but the same length as the main language tra
 
 import os
 from pymediainfo import MediaInfo
+import pipes
 import logger
 import shlex
 import subprocess

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -65,7 +65,7 @@ class ForcedSubs(object):
         MEDIADIR = os.path.join(dbvideo.path, dbvideo.filename)
         self.log.debug("I think the filepath to the media file is {}.".format(MEDIADIR))
 #        wrapper class for mediainfo tool
-        media_info = MediaInfo.parse(MEDIADIR)
+        media_info = MediaInfo.parse(pipes.quote(MEDIADIR))
         subs = []
 #       Iterates though tracks and finds subtitles in preferred language, creates
 #       list of dictionaries

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -63,6 +63,7 @@ class ForcedSubs(object):
                 Else, None
         """
         MEDIADIR = os.path.join(dbvideo.path, dbvideo.filename)
+        self.log.debug("I think the filepath to the media file is {}.".format(MEDIADIR))
 #        wrapper class for mediainfo tool
         media_info = MediaInfo.parse(MEDIADIR)
         subs = []

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -73,7 +73,7 @@ class ForcedSubs(object):
             if data['track_type'] == 'Text' and data['language']==self.lang:
                 subs.append(data)
         if len(subs) <= 1:
-            self.log.info("Only one {} found, cannot determine foreign language track."
+            self.log.info("Only one {} subtitle found, cannot determine foreign language track."
                           .format(self.lang))
             return None
 

--- a/classes/mediainfo.py
+++ b/classes/mediainfo.py
@@ -73,7 +73,10 @@ class ForcedSubs(object):
             data = track.to_data()
             if data['track_type'] == 'Text' and data['language']==self.lang:
                 subs.append(data)
-        if len(subs) <= 1:
+        if len(subs) is 0:
+            self.log.info("No subtitle found, cannot determine foreign language track.")
+            return None
+        if len(subs) is 1:
             self.log.info("Only one {} subtitle found, cannot determine foreign language track."
                           .format(self.lang))
             return None

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -139,5 +139,5 @@ ForcedSubs:
     # Langauge of main subtitle
     language:        en
 
-    # Ratio of secondary subtitle file size to main subtitle size. ie, says will look for susbtitle tracks <= 10% of main track.
+    # Ratio of secondary subtitle file size to main subtitle size. ie, says will look for subtitle tracks <= 10% of main track.
     ratio:           .1

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -140,4 +140,4 @@ ForcedSubs:
     language:        en
 
     # Ratio of secondary subtitle file size to main subtitle size. ie, says will look for susbtitle tracks <= 10% of main track.
-    ratio:      	   .1
+    ratio:           .1

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -125,9 +125,19 @@ notification:
             user_key:
 
             app_key:
+
 ForcedSubs:
-    enable: True
-    mediainfoPath: ""
+    # Enable foreign subtitle detection and flagging
+    enable:          True
+
+    # Path to mediainfo in case it is not in $PATH
+    mediainfoPath:   ""
+
+    # Path to mkvpropedit in case it is not in $PATH
     mkvpropeditPath: ""
-    language: en
-    ratio: .1
+
+    # Langauge of main subtitle
+    language:        en
+
+    # Ratio of secondary subtitle file size to main subtitle size. ie, says will look for susbtitle tracks <= 10% of main track.
+    ratio:      	   .1

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -125,3 +125,9 @@ notification:
             user_key:
 
             app_key:
+ForcedSubs:
+    enable: True
+    mediainfoPath: ""
+    mkvpropeditPath: ""
+    language: en
+    ratio: .1


### PR DESCRIPTION
Added two functionalities:

1) Forced subtitles. I noticed that makemkv rarely detects foreign language subtitles correctly and tags them in the mkv file. This tool can be enabled in the config file and merely searches for a subtitle in the main language that is a certain percentage smaller than the main subtitle, with a comparable length, and tags them using mkvprop edit. Thus, to use it mediainfo and mkvpropedit need to be installed. . More in the mediainfo.py class docstring.

2) Force using a certain DB. I noticed that filebot lookup would fail frequently as it was searching in the wrong database. A simple command line tag allows for forcing "movie" or "tv" lookup. 