### PR TITLE
Updated Makemkv Version As Old Version Returns 404

### DIFF
--- a/build_makemkv/Dockerfile
+++ b/build_makemkv/Dockerfile
@@ -2,21 +2,21 @@ FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y python-virtualenv build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev 
 
-ADD http://www.makemkv.com/download/makemkv-oss-1.10.2.tar.gz /src/
-ADD http://www.makemkv.com/download/makemkv-bin-1.10.2.tar.gz /src/
+ADD http://www.makemkv.com/download/makemkv-oss-1.12.3.tar.gz /src/
+ADD http://www.makemkv.com/download/makemkv-bin-1.12.3.tar.gz /src/
 
-RUN tar xf /src/makemkv-bin-1.10.2.tar.gz -C /src
+RUN tar xf /src/makemkv-bin-1.12.3.tar.gz -C /src
 
 
-RUN mkdir /src/makemkv-bin-1.10.2/tmp/
-RUN echo 'accepted' > /src/makemkv-bin-1.10.2/tmp/eula_accepted
+RUN mkdir /src/makemkv-bin-1.12.3/tmp/
+RUN echo 'accepted' > /src/makemkv-bin-1.12.3/tmp/eula_accepted
 
-RUN  sed -ie 's#DESTDIR=#DESTDIR=/build#g' /src/makemkv-bin-1.10.2/Makefile
+RUN  sed -ie 's#DESTDIR=#DESTDIR=/build#g' /src/makemkv-bin-1.12.3/Makefile
 
-RUN cd /src/makemkv-bin-1.10.2 && make install
+RUN cd /src/makemkv-bin-1.12.3 && make install
 
-RUN tar xf /src/makemkv-oss-1.10.2.tar.gz -C /src
+RUN tar xf /src/makemkv-oss-1.12.3.tar.gz -C /src
 
-RUN cd /src/makemkv-oss-1.10.2 && ./configure --prefix /build/usr --disable-gui && make install
+RUN cd /src/makemkv-oss-1.12.3 && ./configure --prefix /build/usr --disable-gui && make install
 
 CMD ["tar", "cz", "/build"]


### PR DESCRIPTION
It looks like makemkv deletes old versions from that directory when a new version comes out. I just changed the numbers to the newest version but it might be better to have a small script find what the newest version is and use that instead of a fixed number as this will inevitably stop working after a new version comes out.